### PR TITLE
Fix the debug log level check in the attachRequest

### DIFF
--- a/src/IotjsDebugger.ts
+++ b/src/IotjsDebugger.ts
@@ -110,7 +110,7 @@ class IotjsDebugSession extends DebugSession {
     }
 
     this._args = args;
-    if (args.debugLog && args.debugLog in LOG_LEVEL) {
+    if (args.debugLog in LOG_LEVEL) {
       this._debugLog = args.debugLog;
     } else {
       this.sendErrorResponse(response, new Error('No log level given'));


### PR DESCRIPTION
Remove the first condition from the if statement because if the
debugLog is 0 then the condition runs into false.
The second condition covers the 0 level.

IoT.js-VSCode-DCO-1.0-Signed-off-by: Imre Kiss kissi.szeged@partner.samsung.com