### PR TITLE
Fixed Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
-node_js: 8
+node_js: 10
 os: linux
+dist: trusty
+
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;


### PR DESCRIPTION
Downgrade Ubuntu version to 14.04(thursty) on Travis, because CI cannot
open VSCode for tests on Ubuntu 16.04 (Xenial). Also updated the version
of Node.js to the latest LTS version (v10.x).

IoT.js-VSCode-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com